### PR TITLE
Allow (re)submitting a JSON measurement

### DIFF
--- a/integration-tests.cpp
+++ b/integration-tests.cpp
@@ -16,6 +16,7 @@ static std::string collector_baseurl() {
 
 static std::string open_report() {
   mk::collector::OpenRequest r;
+  mk::collector::Settings s;
   r.probe_asn = "AS30722";
   r.probe_cc = "IT";
   r.software_name = "mkcollector";
@@ -23,15 +24,15 @@ static std::string open_report() {
   r.test_name = "dummy";
   r.test_version = "0.0.1";
   r.test_start_time = "2018-11-01 15:33:17";
-  r.base_url = collector_baseurl();
-  r.ca_bundle_path = ".mkbuild/data/cacert.pem";
-  r.timeout = 14;
-  mk::collector::OpenResponse re = mk::collector::open(r);
+  s.base_url = collector_baseurl();
+  s.ca_bundle_path = ".mkbuild/data/cacert.pem";
+  s.timeout = 14;
+  mk::collector::OpenResponse re = mk::collector::open(r, s);
   {
     REQUIRE(re.logs.size() > 0);
     std::clog << "=== BEGIN OPEN LOGS ===" << std::endl;
-    for (auto &s : re.logs) {
-      std::clog << s << std::endl;
+    for (auto &line : re.logs) {
+      std::clog << line << std::endl;
     }
     std::clog << "=== END OPEN LOGS ===" << std::endl;
   }
@@ -68,17 +69,18 @@ static std::string dummy_report(std::string report_id) {
 
 static void update_report(std::string report_id) {
   mk::collector::UpdateRequest r;
+  mk::collector::Settings s;
   r.report_id = report_id;
   r.content = dummy_report(report_id);
-  r.base_url = collector_baseurl();
-  r.ca_bundle_path = ".mkbuild/data/cacert.pem";
-  r.timeout = 14;
-  mk::collector::UpdateResponse re = mk::collector::update(r);
+  s.base_url = collector_baseurl();
+  s.ca_bundle_path = ".mkbuild/data/cacert.pem";
+  s.timeout = 14;
+  mk::collector::UpdateResponse re = mk::collector::update(r, s);
   {
     REQUIRE(re.logs.size() > 0);
     std::clog << "=== BEGIN UPDATE LOGS ===" << std::endl;
-    for (auto &s : re.logs) {
-      std::clog << s << std::endl;
+    for (auto &line : re.logs) {
+      std::clog << line << std::endl;
     }
     std::clog << "=== END UPDATE LOGS ===" << std::endl;
   }
@@ -89,16 +91,17 @@ TEST_CASE("We can open, update, and close a report") {
   std::string report_id = open_report();
   update_report(report_id);
   mk::collector::CloseRequest r;
+  mk::collector::Settings s;
   r.report_id = report_id;
-  r.base_url = collector_baseurl();
-  r.ca_bundle_path = ".mkbuild/data/cacert.pem";
-  r.timeout = 14;
-  mk::collector::CloseResponse re = mk::collector::close(r);
+  s.base_url = collector_baseurl();
+  s.ca_bundle_path = ".mkbuild/data/cacert.pem";
+  s.timeout = 14;
+  mk::collector::CloseResponse re = mk::collector::close(r, s);
   {
     REQUIRE(re.logs.size() > 0);
     std::clog << "=== BEGIN CLOSE LOGS ===" << std::endl;
-    for (auto &s : re.logs) {
-      std::clog << s << std::endl;
+    for (auto &line : re.logs) {
+      std::clog << line << std::endl;
     }
     std::clog << "=== END CLOSE LOGS ===" << std::endl;
   }

--- a/mkcollector.hpp
+++ b/mkcollector.hpp
@@ -12,6 +12,19 @@
 namespace mk {
 namespace collector {
 
+/// Settings contains common network related settings.
+class Settings {
+ public:
+  /// base_url is the OONI collector base_url
+  std::string base_url;
+
+  /// ca_bundle_path is the path to the CA bundle (required on mobile)
+  std::string ca_bundle_path;
+
+  /// timeout is the whole operation timeout (in seconds)
+  int64_t timeout = 30;
+};
+
 /// OpenRequest is a request to open a report with a collector.
 class OpenRequest {
  public:
@@ -35,15 +48,6 @@ class OpenRequest {
 
   /// test_start_time is the time when the test started
   std::string test_start_time;
-
-  /// base_url is the OONI collector base_url
-  std::string base_url;
-
-  /// ca_bundle_path is the path to the CA bundle (required on mobile)
-  std::string ca_bundle_path;
-
-  /// timeout is the whole operation timeout (in seconds)
-  int64_t timeout = 30;
 };
 
 /// OpenResponse is the response to an open request.
@@ -59,7 +63,8 @@ struct OpenResponse {
 };
 
 /// open opens a report with a collector.
-OpenResponse open(const OpenRequest &request) noexcept;
+OpenResponse open(const OpenRequest &request,
+                  const Settings &settings) noexcept;
 
 /// UpdateRequest is a request to update a report with a new measurement.
 struct UpdateRequest {
@@ -68,15 +73,6 @@ struct UpdateRequest {
 
   /// content is the measurement entry serialised as a string.
   std::string content;
-
-  /// base_url is the OONI collector base URL.
-  std::string base_url;
-
-  /// ca_bundle_path is the path to the CA bundle (required on mobile).
-  std::string ca_bundle_path;
-
-  /// timeout is the whole-operation timeout (in seconds).
-  int64_t timeout = 30;
 };
 
 /// UpdateResponse is a response to an update request.
@@ -88,21 +84,13 @@ struct UpdateResponse {
 };
 
 /// update updates a report by adding a new measurement.
-UpdateResponse update(const UpdateRequest &request) noexcept;
+UpdateResponse update(const UpdateRequest &request,
+                      const Settings &settings) noexcept;
 
 /// CloseRequest is a request to close a report.
 struct CloseRequest {
   /// report_id is the report ID
   std::string report_id;
-
-  /// base_url is OONI collector's base URL
-  std::string base_url;
-
-  /// ca_bundle_path is the path to the CA bundle (required on mobile)
-  std::string ca_bundle_path;
-
-  /// timeout is the whole-operation timeout (in seconds)
-  int64_t timeout = 30;
 };
 
 /// CloseResponse is a response to a close request
@@ -115,7 +103,8 @@ struct CloseResponse {
 };
 
 /// close closes a report.
-CloseResponse close(const CloseRequest &request) noexcept;
+CloseResponse close(const CloseRequest &request,
+                    const Settings &settings) noexcept;
 
 }  // namespace collector
 }  // namespace mk
@@ -148,15 +137,16 @@ static void log_body(const std::string &prefix, const std::string &body,
   logs.push_back(ss.str());
 }
 
-OpenResponse open(const OpenRequest &request) noexcept {
+OpenResponse open(const OpenRequest &request,
+                  const Settings &settings) noexcept {
   OpenResponse response;
   curl::Request curl_request;
-  curl_request.ca_path = request.ca_bundle_path;
-  curl_request.timeout = request.timeout;
+  curl_request.ca_path = settings.ca_bundle_path;
+  curl_request.timeout = settings.timeout;
   curl_request.method = "POST";
   curl_request.headers.push_back("Content-Type: application/json");
   {
-    std::string url = request.base_url;
+    std::string url = settings.base_url;
     url += "/report";
     std::swap(url, curl_request.url);
   }
@@ -207,15 +197,16 @@ OpenResponse open(const OpenRequest &request) noexcept {
   return response;
 }
 
-UpdateResponse update(const UpdateRequest &request) noexcept {
+UpdateResponse update(const UpdateRequest &request,
+                      const Settings &settings) noexcept {
   UpdateResponse response;
   curl::Request curl_request;
-  curl_request.ca_path = request.ca_bundle_path;
-  curl_request.timeout = request.timeout;
+  curl_request.ca_path = settings.ca_bundle_path;
+  curl_request.timeout = settings.timeout;
   curl_request.method = "POST";
   curl_request.headers.push_back("Content-Type: application/json");
   {
-    std::string url = request.base_url;
+    std::string url = settings.base_url;
     url += "/report/";
     url += request.report_id;
     std::swap(url, curl_request.url);
@@ -259,14 +250,15 @@ UpdateResponse update(const UpdateRequest &request) noexcept {
   return response;
 }
 
-CloseResponse close(const CloseRequest &request) noexcept {
+CloseResponse close(const CloseRequest &request,
+                    const Settings &settings) noexcept {
   CloseResponse response;
   curl::Request curl_request;
   curl_request.method = "POST";
-  curl_request.ca_path = request.ca_bundle_path;
-  curl_request.timeout = request.timeout;
+  curl_request.ca_path = settings.ca_bundle_path;
+  curl_request.timeout = settings.timeout;
   {
-    std::string url = request.base_url;
+    std::string url = settings.base_url;
     url += "/report/";
     url += request.report_id;
     url += "/close";

--- a/tests.cpp
+++ b/tests.cpp
@@ -191,3 +191,31 @@ TEST_CASE("We deal with close errors") {
     });
   }
 }
+
+TEST_CASE("open_request_from_measurement works as expected") {
+  SECTION("with good input") {
+    auto str = R"({
+      "probe_asn": "AS0",
+      "probe_cc": "ZZ",
+      "software_name": "mkcollector",
+      "software_version": "0.0.1",
+      "test_name": "dummy",
+      "test_start_time": "2018-11-01 15:33:17",
+      "test_version": "0.0.1"
+    })";
+    auto re = mk::collector::open_request_from_measurement(str);
+    REQUIRE(re.good);
+    REQUIRE(re.value.probe_asn == "AS0");
+    REQUIRE(re.value.probe_cc == "ZZ");
+    REQUIRE(re.value.software_name == "mkcollector");
+    REQUIRE(re.value.software_version == "0.0.1");
+    REQUIRE(re.value.test_name == "dummy");
+    REQUIRE(re.value.test_start_time == "2018-11-01 15:33:17");
+    REQUIRE(re.value.test_version == "0.0.1");
+  }
+
+  SECTION("with bad input") {
+    auto re = mk::collector::open_request_from_measurement("{}");
+    REQUIRE(!re.good);
+  }
+}

--- a/tests.cpp
+++ b/tests.cpp
@@ -41,14 +41,16 @@ TEST_CASE("We deal with open errors") {
     mk::collector::OpenRequest request;
     request.probe_cc = std::string{(const char *)binary_input,
                                    sizeof(binary_input)};
-    auto response = mk::collector::open(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::open(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("On network error") {
     MKMOCK_WITH_ENABLED_HOOK(open_response_error, CURL_LAST, {
       mk::collector::OpenRequest request;
-      auto response = mk::collector::open(request);
+      mk::collector::Settings settings;
+      auto response = mk::collector::open(request, settings);
       REQUIRE(!response.good);
     });
   }
@@ -57,7 +59,8 @@ TEST_CASE("We deal with open errors") {
     MKMOCK_WITH_ENABLED_HOOK(open_response_error, 0, {
       MKMOCK_WITH_ENABLED_HOOK(open_response_status_code, 500, {
         mk::collector::OpenRequest request;
-        auto response = mk::collector::open(request);
+        mk::collector::Settings settings;
+        auto response = mk::collector::open(request, settings);
         REQUIRE(!response.good);
       });
     });
@@ -68,7 +71,8 @@ TEST_CASE("We deal with open errors") {
       MKMOCK_WITH_ENABLED_HOOK(open_response_status_code, 200, {
         MKMOCK_WITH_ENABLED_HOOK(open_response_body, "{", {
           mk::collector::OpenRequest request;
-          auto response = mk::collector::open(request);
+          mk::collector::Settings settings;
+          auto response = mk::collector::open(request, settings);
           REQUIRE(!response.good);
         });
       });
@@ -80,42 +84,48 @@ TEST_CASE("We deal with update errors") {
   SECTION("On failure to serialize the request body") {
     mk::collector::UpdateRequest request;
     request.content = "{";  // make content parsing fail
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("When the data_format_version field is missing") {
     mk::collector::UpdateRequest request;
     request.content = "{}";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("When the data_format_version field is not a string") {
     mk::collector::UpdateRequest request;
     request.content = R"({"data_format_version": []})";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("When the data_format_version field is inconsistent") {
     mk::collector::UpdateRequest request;
     request.content = R"({"data_format_version": "0.1.0"})";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("When the report_id field is missing") {
     mk::collector::UpdateRequest request;
     request.content = R"({"data_format_version": "0.2.0"})";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
   SECTION("When the report_id field is not a string") {
     mk::collector::UpdateRequest request;
     request.content = R"({"data_format_version": "0.2.0", "report_id": []})";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
@@ -125,7 +135,8 @@ TEST_CASE("We deal with update errors") {
     mk::collector::UpdateRequest request;
     request.report_id = report_id;
     request.content = R"({"data_format_version": "0.2.0", "report_id": "xx"})";
-    auto response = mk::collector::update(request);
+    mk::collector::Settings settings;
+    auto response = mk::collector::update(request, settings);
     REQUIRE(!response.good);
   }
 
@@ -139,7 +150,8 @@ TEST_CASE("We deal with update errors") {
       mk::collector::UpdateRequest request;
       request.content = minimal_good_content;
       request.report_id = report_id;
-      auto response = mk::collector::update(request);
+      mk::collector::Settings settings;
+      auto response = mk::collector::update(request, settings);
       REQUIRE(!response.good);
     });
   }
@@ -150,7 +162,8 @@ TEST_CASE("We deal with update errors") {
         mk::collector::UpdateRequest request;
         request.content = minimal_good_content;
         request.report_id = report_id;
-        auto response = mk::collector::update(request);
+        mk::collector::Settings settings;
+        auto response = mk::collector::update(request, settings);
         REQUIRE(!response.good);
       });
     });
@@ -161,7 +174,8 @@ TEST_CASE("We deal with close errors") {
   SECTION("On network error") {
     MKMOCK_WITH_ENABLED_HOOK(close_response_error, CURL_LAST, {
       mk::collector::CloseRequest request;
-      auto response = mk::collector::close(request);
+      mk::collector::Settings settings;
+      auto response = mk::collector::close(request, settings);
       REQUIRE(!response.good);
     });
   }
@@ -170,7 +184,8 @@ TEST_CASE("We deal with close errors") {
     MKMOCK_WITH_ENABLED_HOOK(close_response_error, 0, {
       MKMOCK_WITH_ENABLED_HOOK(close_response_status_code, 500, {
         mk::collector::CloseRequest request;
-        auto response = mk::collector::close(request);
+        mk::collector::Settings settings;
+        auto response = mk::collector::close(request, settings);
         REQUIRE(!response.good);
       });
     });


### PR DESCRIPTION
This implements https://github.com/measurement-kit/measurement-kit/issues/1743 with much less complexity than in https://github.com/measurement-kit/mkreport/tree/v0.1.0.